### PR TITLE
feat: add plugin options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { parser } from "./parser";
 import { printer } from "./printer";
-import { Plugin } from "prettier";
+import { Plugin, SupportOptions } from "prettier";
 
 const languages = [
   {
@@ -10,6 +10,21 @@ const languages = [
   },
 ];
 
+const options: SupportOptions = {
+  envAlign: {
+    type: "boolean",
+    category: "env",
+    default: false,
+    description: "Align equal signs in .env files",
+  },
+  envOrder: {
+    type: "boolean",
+    category: "env",
+    default: true,
+    description: "Sort keys in .env files",
+  },
+};
+
 const plugin: Plugin = {
   languages,
   parsers: {
@@ -18,10 +33,7 @@ const plugin: Plugin = {
   printers: {
     "dotenv-ast": printer,
   },
-  options: {
-    // Define any plugin-specific options here
-    // For example, you could add an option to control the formatting style
-  },
+  options,
 };
 
 export default plugin;

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -5,11 +5,23 @@ import { DotenvNode } from "./types/dotenv-node";
 import { transformAlignSpaces } from "./transformers/transform-align-spaces";
 import { joinLine } from "./lib/join-line";
 import { transformOrder } from "./transformers/transform-order";
+import { DotenvPluginOptions } from "./types/dotenv-plugin-options";
 
-const print: Printer<DotenvNode[]>["print"] = (path) => {
+const print: Printer<DotenvNode[]>["print"] = (path, options) => {
+  const { envAlign = false, envOrder = true } = options as DotenvPluginOptions;
+
   const ast = path.stack[0];
 
-  const transformedAst = transform(ast, [transformOrder, transformAlignSpaces]);
+  const transformedAst = transform(ast, [
+    {
+      condition: envOrder,
+      transform: transformOrder,
+    },
+    {
+      condition: envAlign,
+      transform: transformAlignSpaces,
+    },
+  ]);
   return transformedAst.map((node) => joinLine(node)).join("\n");
 };
 

--- a/src/types/dotenv-plugin-options.ts
+++ b/src/types/dotenv-plugin-options.ts
@@ -1,0 +1,4 @@
+export type DotenvPluginOptions = {
+  envAlign?: boolean;
+  envOrder?: boolean;
+};

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -12,6 +12,8 @@ describe("Plugin Tests", async () => {
       const output = await prettier.format(input, {
         parser: "dotenv",
         plugins: [plugin],
+        envAlign: true,
+        envOrder: true,
       });
       expect(output).toEqual(expected);
     }

--- a/test/print.test.ts
+++ b/test/print.test.ts
@@ -7,7 +7,10 @@ const print = (input: DotenvNode[]) =>
     {
       stack: [input],
     } as any,
-    {} as any,
+    {
+      envAlign: true,
+      envOrder: true,
+    } as any,
     {} as any
   );
 


### PR DESCRIPTION
What changed:
- added plugin options
  - envOrder: controls if key ordering is turned on
  - envAlign: controls if value and `=` sign alignment is turned on

